### PR TITLE
revised fundamental overview page and navigation

### DIFF
--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -1,1 +1,0 @@
-../_external/data/navigation.yml

--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -46,7 +46,7 @@
           es: 'Registro de cambios'
         url: /videos/standards-and-benefits/changelog/
         hide: true        
-  - name: "Accessibility: It's About People"
+  - name: "Accessibility is About People"
     url: "/people/"
     pages:
     - name: Perspectives Videos

--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -1,0 +1,743 @@
+- name:
+    en: "Accessibility Fundamentals"
+    es: "Fundamentos de accesibilidad"
+    fr: "Fondamentaux de l'accessibilité"
+  pages:
+  - name:
+      en: 'Accessibility Fundamentals'
+      es: 'Fundamentos de accesibilidad'
+      fr: "Fondamentaux de l'accessibilité"
+    url: "/fundamentals/"
+  - name: Changelog
+    url: "/fundamentals/changelog/"
+    hide: true
+  - name:
+      en: "Introduction to Accessibility"
+      ar: "مقدمة لولوجية الويب"
+      cs: "Úvod do webové přístupnosti"
+      es: "Introducción a la Accesibilidad Web"
+      fr: "Introduction à l'accessibilité du web"
+      id: "Pengenalan pada Aksesibilitas Web"
+      ru: "ВВЕДЕНИЕ В ВЕБ-ДОСТУПНОСТЬ"
+      zh-hans: "Web无障碍简介"
+    url: "/fundamentals/accessibility-intro/"
+    pages:
+    - name:
+        en: 'Video Introduction'
+        ar: 'مقدمة فيديو'
+        cs: 'Video úvod'
+        de: 'Video-Einführung'
+        el: 'Εισαγωγή Βίντεο'
+        es: 'Vídeo de Introducción'
+        fr: 'Vidéo : introduction'
+        ja: '紹介'
+        nl: 'Video-introductie'
+        ru: 'Введение'
+        zh-hans: '视频介绍'
+      url: /videos/standards-and-benefits/
+      pages:
+      - name:
+          en: Changelog
+          de: 'Änderungsprotokoll'
+          nl: 'Changelog.'
+          el: 'Change log'
+          zh-hans: '修改日志'
+          fr: 'Changements'
+          es: 'Registro de cambios'
+        url: /videos/standards-and-benefits/changelog/
+        hide: true        
+  - name: "Accessibility: It's About People"
+    url: "/people/"
+    pages:
+    - name: Perspectives Videos
+      url: "/perspective-videos/"
+      pages:
+      - name: Keyboard Compatibility
+        url: "/perspective-videos/keyboard/"
+      - name: Colors with Good Contrast
+        url: "/perspective-videos/contrast/"
+      - name: Clear Layout and Design
+        url: "/perspective-videos/layout/"
+      - name: Text to Speech
+        url: "/perspective-videos/speech/"
+      - name: Large Links, Buttons, and Controls
+        url: "/perspective-videos/controls/"
+      - name: Video Captions
+        url: "/perspective-videos/captions/"
+      - name: Customizable Text
+        url: "/perspective-videos/customizable/"
+      - name: Speech Recognition
+        url: "/perspective-videos/voice/"
+      - name: Understandable Content
+        url: "/perspective-videos/understandable/"
+      - name: Notifications and Feedback
+        url: "/perspective-videos/notifications/"
+      - name: Acknowledgements
+        url: "/perspective-videos/acknowledgements/"
+        hide: true
+    - name:
+        en: "How People with Disabilities Use the Web, Videos"
+        fr: "Comment les personnes handicapées utilisent le web"
+        es: "Cómo usan la web las personas con discapacidad"
+      url: "/people-use-web/"
+      pages:
+      - name:
+          en: "Stories of Web Users"
+          fr: "Quelques utilisateurs du Web"
+          es: "Historias de usuarios de la web"
+        url: "/people-use-web/user-stories/"
+      - name:
+          en: "Diverse Abilities and Barriers"
+          fr: "Des capacités et des points bloquants variés"
+        url: "/people-use-web/abilities-barriers/"
+      - name:
+          en: "Tools and Techniques"
+          fr: "Outils et techniques"
+        url: "/people-use-web/tools-techniques/"
+      - name: Videos of How People Use the Web
+        url: "/people-use-web/videos/"
+    - name: Older Users and Accessibility
+      url: "/older-users/"
+      pages:
+      - name: How WCAG 2 Applies
+        url: "/older-users/developing/"
+      - name: Literature Review
+        url: "/older-users/literature/"
+      - name: Changelog
+        url: "/older-users/changelog/"
+        hide: true
+    - name: Accessibility, Usability, Inclusion
+      url: "/fundamentals/accessibility-usability-inclusion/"
+  - name:
+      en: Components of Web Accessibility
+      ko: "웹 접근성 요소"
+    url: "/fundamentals/components/"
+    pages:
+    - name:
+        en: Illustration Descriptions
+      url: "/fundamentals/components/examples/"
+      hide: true
+  - name:
+      en: "Accessibility Principles"
+      fr: "Principes d’accessibilité"
+      es: "Principios de accesibilidad"
+      zh-hans: "无障碍原则"
+    url: "/fundamentals/accessibility-principles/"
+    pages:
+      - name:
+          en: Changelog
+          de: 'Änderungsprotokoll'
+          nl: 'Changelog.'
+          el: 'Change log'
+          zh-hans: '修改日志'
+          fr: 'Changements'
+          es: 'Registro de cambios'
+        url: "/fundamentals/accessibility-principles/changelog/"
+        hide: true
+  - name: Digital Accessibility Courses
+    url: "/courses/"
+    pages:
+    - name: W3C Foundations Online Course
+      url: "/courses/foundations-course/"
+    - name: Course List
+      url: "/courses/list/"
+      pages:
+      - name: Submit a course
+        url: "/courses/submission/"
+        hide: true	
+- name:
+    en: 'Planning & Policies'
+    es: 'Planificación y Políticas'
+    fr: 'Organisation & politiques'
+  pages:
+  - name:
+      en: 'Planning & Policies'
+      es: 'Planificación y Políticas'
+      fr: 'Organisation & politiques'
+    url: "/planning/"
+  - name: Changelog
+    url: "/planning/changelog/"
+    hide: true
+  - name: Approaches for Interim Repairs
+    url: "/planning/interim-repairs/"
+  - name: Planning and Managing Accessibility
+    url: "/planning-and-managing/"
+    pages:
+      - name: Initiate
+        url: "/planning-and-managing/initiate/"
+      - name: Plan
+        url: "/planning-and-managing/plan/"
+      - name: Implement
+        url: "/planning-and-managing/implement/"
+      - name: Sustain
+        url: "/planning-and-managing/sustain/"
+      - name: Authoring Tools List
+        url: "/tools-list/authoring/"
+      - name: Authoring Tool Submission Form
+        url: "/tools-list/authoring/submit-a-tool/"
+        hide: true
+  - name: Developing an Organizational Policy
+    url: "/planning/org-policies/"
+    pages:
+      - name: Example
+        url: "/planning/org-policies/example/"
+  - name: Developing an Accessibility Statement
+    url: "/planning/statements/"
+    pages:
+    - name: Generator Tool
+      url: "/planning/statements/generator/"
+    - name: Minimal Example
+      url: "/planning/statements/minimal-example/"
+    - name: Complete Example
+      url: "/planning/statements/complete-example/"
+  - name: Involving Users for Better Accessibility
+    url: "/planning/involving-users/"
+  - name: International Laws & Policies
+    url: "/policies/"
+- name:
+    en: 'Design & Develop'
+    es: 'Diseñar y Desarrollar'
+    fr: 'Concevoir & développer'
+  pages:
+  - name:
+      en: 'Design & Develop'
+      es: 'Diseñar y Desarrollar'
+      fr: 'Concevoir & développer'
+    url: "/design-develop/"
+  - name: Changelog
+    url: "/design-develop/changelog/"
+    hide: true
+  - name: Tips for Getting Started
+    url: "/tips/"
+    hide: true
+  - name: Tips for Writing
+    url: "/tips/writing/"
+  - name: Tips for Designing
+    url: "/tips/designing/"
+  - name: Tips for Developing
+    url: "/tips/developing/"
+  - name: Audio & Video Media
+    url: "/media/av/"
+    pages:
+      - name: User Needs
+        url: "/media/av/users-orgs/"
+      - name: Planning
+        url: "/media/av/planning/"
+      - name: Audio Content & Video Content
+        url: "/media/av/av-content/"
+      - name: Description
+        url: "/media/av/description/"
+      - name: Captions/Subtitles
+        url: "/media/av/captions/"
+      - name: Transcripts
+        url: "/media/av/transcripts/"
+      - name: Transcribing Audio to Text
+        url: "/media/av/transcribing/"
+      - name: Sign Languages
+        url: "/media/av/sign-languages/"
+      - name: Media Player
+        url: "/media/av/player/"
+      - name:
+          en: Acknowledgements
+        url: /media/av/acknowledgements/
+        hide: true
+      - name:
+          en: Changelog
+        url: /media/av/changelog/
+        hide: true
+  - name: Tutorials
+    url: "/tutorials/"
+    pages:
+    - name: Page Structure
+      url: "/tutorials/page-structure/"
+      pages:
+      - name: Page Regions
+        url: "/tutorials/page-structure/regions/"
+      - name: Labeling Regions
+        url: "/tutorials/page-structure/labels/"
+      - name: Headings
+        url: "/tutorials/page-structure/headings/"
+      - name: Content Structure
+        url: "/tutorials/page-structure/content/"
+      - name: Full Example
+        url: "/tutorials/page-structure/example/"
+    - name: "Menus"
+      url: "/tutorials/menus/"
+      pages:
+      - name: Structure
+        url: "/tutorials/menus/structure/"
+      - name: Styling
+        url: "/tutorials/menus/styling/"
+      - name: Fly-Out Menus
+        url: "/tutorials/menus/flyout/"
+      - name: Application Menus
+        url: "/tutorials/menus/application-menus/"
+      - name: Application Menu Example & Code
+        url: "/tutorials/menus/application-menus-code/"
+    - name: Images
+      url: "/tutorials/images/"
+      pages:
+      - name: Informative Images
+        url: "/tutorials/images/informative/"
+      - name: Decorative Images
+        url: "/tutorials/images/decorative/"
+      - name: Functional Images
+        url: "/tutorials/images/functional/"
+      - name: Images of Text
+        url: "/tutorials/images/textual/"
+      - name: Complex Images
+        url: "/tutorials/images/complex/"
+        pages:
+        - name: Example
+          url: "/tutorials/images/examples/2014-first-qtr/"
+          hide: true
+      - name: Groups of Images
+        url: "/tutorials/images/groups/"
+      - name: Image Maps
+        url: "/tutorials/images/imagemap/"
+        pages:
+        - name: Example
+          url: "/tutorials/images/examples/imagemap/"
+          hide: true
+      - name: 'An <code style="color: inherit;">alt</code> Decision Tree'
+        url: "/tutorials/images/decision-tree/"
+      - name: Tips and Tricks
+        url: "/tutorials/images/tips/"
+    - name: Tables
+      url: "/tutorials/tables/"
+      pages:
+      - name: One Header
+        url: "/tutorials/tables/one-header/"
+      - name: Two Headers
+        url: "/tutorials/tables/two-headers/"
+        pages:
+        - name: "Complete “Table with header cells in the top row only” Example"
+          url: /tutorials/tables/examples/headertoprowfirstcol/
+          hide: true
+      - name: Irregular Headers
+        url: "/tutorials/tables/irregular/"
+      - name: Multi-level Headers
+        url: "/tutorials/tables/multi-level/"
+      - name: Caption & Summary
+        url: "/tutorials/tables/caption-summary/"
+      - name: Tips and Tricks
+        url: "/tutorials/tables/tips/"
+    - name: "Forms"
+      url: "/tutorials/forms/"
+      pages:
+      - name: Labeling Controls
+        url: "/tutorials/forms/labels/"
+      - name: Grouping Controls
+        url: "/tutorials/forms/grouping/"
+      - name: Form Instructions
+        url: "/tutorials/forms/instructions/"
+      - name: Validating Input
+        url: "/tutorials/forms/validation/"
+      - name: User Notifications
+        url: "/tutorials/forms/notifications/"
+        pages:
+        - name: Password Example
+          url: "/tutorials/forms/examples/password/"
+          hide: true
+      - name: Multi-page Forms
+        url: "/tutorials/forms/multi-page/"
+      - name: Custom Controls
+        url: "/tutorials/forms/custom-controls/"
+    - name: "Carousels"
+      url: "/tutorials/carousels/"
+      pages:
+      - name: Structure
+        url: "/tutorials/carousels/structure/"
+      - name: Functionality
+        url: "/tutorials/carousels/functionality/"
+      - name: Animations
+        url: "/tutorials/carousels/animations/"
+      - name: Styling
+        url: "/tutorials/carousels/styling/"
+      - name: Working Example
+        url: "/tutorials/carousels/working-example/"
+      - name: Complete Code
+        url: "/tutorials/carousels/full-code/"
+    - name: "Changelog"
+      url: "/tutorials/changelog/"
+      hide: true
+    - name: "Acknowledgements"
+      url: "/tutorials/acknowledgements/"
+      hide: true
+
+- name:
+    en: 'Test & Evaluate'
+    es: 'Probar y Evaluar'
+    fr: 'Tester et évaluer'
+  pages:
+  - name:
+      en: 'Test & Evaluate'
+      es: 'Probar y Evaluar'
+      fr: 'Tester et évaluer'
+    url: "/test-evaluate/"
+  - name: Changelog
+    url: "/test-evaluate/changelog/"
+    hide: true
+  - name: Easy Checks – A First Review
+    url: "/test-evaluate/preliminary/"
+  - name:
+      en: 'Evaluation Tools'
+      fr: "Outils d'évaluation"
+    url: "/test-evaluate/tools/"
+    pages:
+      - name: Selecting Evaluation Tools
+        url: "/test-evaluate/tools/selecting/"
+      - name: List of Evaluation Tools
+        url: "https://www.w3.org/WAI/ER/tools/"
+  - name:
+      en: 'Conformance Evaluation, Reports'
+      fr: 'Évaluation de la conformité, rapports'
+    url: "/test-evaluate/conformance/"
+    pages:
+      - name: WCAG-EM Conformance Methodology
+        url: "/test-evaluate/conformance/wcag-em/"
+      - name: WCAG-EM Report Tool
+        url: "https://www.w3.org/WAI/eval/report-tool/"
+      - name: Report Template
+        url: "/test-evaluate/report-template/"
+  - name: Using Combined Expertise
+    url: "/test-evaluate/combined-expertise/"
+  - name:
+      en: 'Involving Users'
+      fr: 'Impliquer les utilisateurs'
+    url: "/test-evaluate/involving-users/"
+  - name: Acknowledgements
+    url: "/test-evaluate/acknowledgements/"
+    hide: true
+
+- name:
+    en: 'Teach & Advocate'
+    es: 'Enseñar y Promover'
+    fr: 'Former et promouvoir'
+  pages:
+  - name:
+      en: 'Teach & Advocate'
+      es: 'Enseñar y Promover'
+      fr: 'Former et promouvoir'
+    url: "/teach-advocate/"
+  - name: Changelog
+    url: "/teach-advocate/changelog/"
+    hide: true
+  - name: Making Events Accessible Checklist
+    url: "/teach-advocate/accessible-presentations/"
+  - name: Curricula on Web Accessibility
+    url: "/curricula/"
+    pages:
+    - name: Foundation Modules
+      url: "/curricula/foundation-modules/"
+      pages:
+      - name: What is Web Accessibility
+        url: "/curricula/foundation-modules/what-is-web-accessibility/"
+      - name: People and Digital Technology
+        url: "/curricula/foundation-modules/people-and-digital-technology/"
+      - name: Business Case and Benefits
+        url: "/curricula/foundation-modules/business-case-and-benefits/"
+      - name: Principles, Standards, and Checks
+        url: "/curricula/foundation-modules/principles-standards-and-checks/"
+      - name: Getting Started with Accessibility
+        url: "/curricula/foundation-modules/getting-started-with-accessibility/"
+    - name: Developer Modules
+      url: "/curricula/developer-modules/"
+      pages:
+      - name: Page Structure
+        url: "/curricula/developer-modules/page-structure/"
+      - name: Menus
+        url: "/curricula/developer-modules/menus/"
+      - name: Images
+        url: "/curricula/developer-modules/images/"
+      - name: Tables
+        url: "/curricula/developer-modules/tables/"
+      - name: Forms
+        url: "/curricula/developer-modules/forms/"
+      - name: Custom Widgets
+        url: "/curricula/developer-modules/custom-widgets/"
+      - name: Rich Applications
+        url: "/curricula/developer-modules/rich-applications/"
+    - name: Designer Modules
+      url: "/curricula/designer-modules/"
+      pages:
+      - name: Visual Design
+        url: "/curricula/designer-modules/visual-design/"
+      - name: Information Design
+        url: "/curricula/designer-modules/information-design/"
+      - name: Navigation Design
+        url: "/curricula/designer-modules/navigation-design/"
+      - name: Interaction Design
+        url: "/curricula/designer-modules/interaction-design/"
+      - name: Images and Graphics
+        url: "/curricula/designer-modules/images-and-graphics/"
+      - name: Multimedia and Animations
+        url: "/curricula/designer-modules/multimedia-and-animations/"
+      - name: Forms Design
+        url: "/curricula/designer-modules/forms-design/"
+    - name: Content Author Modules
+      url: "/curricula/content-author-modules/"
+      pages:
+      - name: Clear Content
+        url: "/curricula/content-author-modules/clear-content/"
+      - name: Structure
+        url: "/curricula/content-author-modules/structure/"
+      - name: Forms
+        url: "/curricula/content-author-modules/forms/"
+      - name: Images
+        url: "/curricula/content-author-modules/images/"
+      - name: Data Tables
+        url: "/curricula/content-author-modules/data-tables/"
+      - name: Multimedia
+        url: "/curricula/content-author-modules/multimedia/"
+  - name: Develop Accessibility Training
+    url: "/teach-advocate/accessibility-training/"
+    pages:
+    - name: Topics
+      url: "/teach-advocate/accessibility-training/topics/"
+    - name: Presentation Outlines
+      url: "/teach-advocate/accessibility-training/presentation-outlines/"
+    - name: Workshop Outline
+      url: "/teach-advocate/accessibility-training/workshop-outline/"
+# - name: Presentations You Can Use
+#   url: "/teach-advocate/presentations-to-use/"
+  - name: Before and After Demo (BAD)
+    url: "https://www.w3.org/WAI/demos/bad/"
+  - name: Contacting Inaccessible Websites
+    url: "/teach-advocate/contact-inaccessible-websites/"
+  - name:
+      en: 'Business Case'
+      es: 'Caso de negocios'
+      fr: 'Bénéfices business'
+    url: "/business-case/"
+    pages:
+    - name: Bibliography
+      url: "/business-case/bibliography/"
+  # pages:
+  #   - name: Social Factors
+  #     url: "/business-case/social-factors/"
+  #   - name: Technical Factors
+  #     url: "/business-case/technical-factors/"
+  #   - name: Financial Factors
+  #     url: "/business-case/financial-factors/"
+  #   - name: Legal & Policy Factors
+  #     url: "/business-case/legal-policy-factors/"
+  #   - name: Resources
+  #     url: "/business-case/resources/"
+
+- name:
+    en: 'Standards/<wbr>Guidelines'
+    es: 'Estándares/<wbr>Pautas'
+    fr: 'Standards/<wbr>Règles'
+  pages:
+  - name:
+      en: 'Standards/<wbr>Guidelines'
+      cs: 'Standardy/Pokyny'
+      es: 'Estándares/<wbr>Pautas'
+      fr: "Standards/<wbr>Règles"
+      ko: "표준/지침"
+      ru: "Стандарты/<wbr>Рекомендации"
+      zh-hans: "标准/指南"
+    url: "/standards-guidelines/"
+  - name: Changelog
+    url: "/standards-guidelines/changelog/"
+    hide: true
+  - name:
+      en: "Web Content – WCAG 2"
+      fr: "Contenus web – WCAG 2"
+      es: "Contenido Web – WCAG 2"
+    url: "/standards-guidelines/wcag/"
+    pages:
+    - name: "How to Meet WCAG 2 (Quick Reference)"
+      url: "https://www.w3.org/WAI/WCAG21/quickref/"
+    - name:
+        en: "At a Glance"
+        es: "De un vistazo"
+        fr: "En bref"
+      url: "/standards-guidelines/wcag/glance/"
+    - name: The Documents
+      url: "/standards-guidelines/wcag/docs/"
+    - name: "Applying to Non-Web ICT"
+      url: "/standards-guidelines/wcag/non-web-ict/"
+    - name: New in 2.2 Draft
+      url: "/standards-guidelines/wcag/new-in-22/"
+    - name:
+        en: "New in 2.1"
+        es: "Novedades en 2.1"
+      url: "/standards-guidelines/wcag/new-in-21/"
+    - name: Translations
+      url: "/standards-guidelines/wcag/translations/"
+    - name: "Commenting"
+      url: "/standards-guidelines/wcag/commenting/"
+    - name: "Conformance Logos"
+      url: "/standards-guidelines/wcag/conformance-logos/"
+    - name: FAQ
+      url: "/standards-guidelines/wcag/faq/"
+  - name: WCAG 3 Draft
+    url: "/standards-guidelines/wcag/wcag3-intro/"
+  - name: Authoring Tools – ATAG
+    url: "/standards-guidelines/atag/"
+    pages:
+    - name: "At a Glance"
+      url: "/standards-guidelines/atag/glance/"
+    - name: "For LMS"
+      url: "/standards-guidelines/atag/education/"
+    - name: "For No-Code Tools"
+      url: "/standards-guidelines/atag/no-code/"
+    - name: "For Social Media Platforms"
+      url: "/standards-guidelines/atag/social-media/"
+  - name: User Agents – UAAG
+    url: "/standards-guidelines/uaag/"
+  - name: WAI-ARIA
+    url: "/standards-guidelines/aria/"
+  - name: Evaluation – ACT & EARL
+    url: "/standards-guidelines/evaluation/"
+    pages:
+    - name: Accessibility Conformance Testing – ACT
+      url: "/standards-guidelines/act/"
+    - name: WCAG ACT Rules
+      url: "/standards-guidelines/act/rules/"
+      hide: true
+      pages:
+      - name: "Rule: HTML page has title"
+        url: "/standards-guidelines/act/rules/html-page-has-title-2779a5/"
+        hide: true
+      - name: "Rule: Image button has accessible name"
+        url: "/standards-guidelines/act/rules/image-button-accessible-name-59796f/"
+        hide: true
+      - name: "Rule: HTML page has ‘lang’ attribute"
+        url: "/standards-guidelines/act/rules/html-page-lang-b5c3f8/"
+        hide: true
+      - name: "Rule: HTML page language is valid"
+        url: "/standards-guidelines/act/rules/html-page-lang-valid-bf051a/"
+        hide: true
+      - name: "Rule: HTML page ‘lang’ and ‘xml:lang’ attributes have matching values"
+        url: "/standards-guidelines/act/rules/html-page-lang-xml-lang-match-5b7ae0/"
+        hide: true
+    - name: Evaluation and Report Language – EARL
+      url: "/standards-guidelines/earl/"
+  - name: WAI-Adapt
+    url: "/adapt/"
+  - name: Pronunciation
+    url: "/pronunciation/"
+  - name: Standards Harmonization is Essential
+    url: "/standards-guidelines/harmonization/"
+  - name: W3C Process for Developing Standards
+    url: "/standards-guidelines/w3c-process/"
+  - name: Referencing and Linking to Standards
+    url: "/standards-guidelines/linking/"
+  - name: Cognitive Accessibility at W3C
+    url: "/cognitive/"
+  - name:
+      en: "Mobile Accessibility at W3C"
+      cs: "Mobilní přístupnost ve W3C"
+      es: "Accesibilidad Móvil en el W3C"
+      fr: "Accessibilité mobile chez W3C"
+      ru: "Решения консорциума W3C по обеспечению доступности на мобильных устройствах"
+      zh-hans: "W3C 移动端无障碍"
+    url: "/standards-guidelines/mobile/"
+
+- name:
+    en: News
+  mainnav: false
+  pages:
+  - name: "News"
+    url: "/news/"
+    pages:
+    - name: "To subscribe:"
+      url: "/news/subscribe/"
+
+- name:
+    en: "About W3C WAI"
+  mainnav: false
+  pages:
+  - name: About WAI
+    url: "/about/"
+  - name: "What We're Working On"
+    url: "/update/"
+  - name: Participating
+    url: "/about/participating/"
+  - name: Groups
+    url: "/about/groups/"
+    pages:
+    - name: 'AGWG: Accessibility Guidelines <abbr title="Working Group">WG</abbr>'
+      url: "https://www.w3.org/WAI/GL/"
+    - name: 'APA: Accessible Platform <abbr title="Working Group">WG</abbr>'
+      url: "https://www.w3.org/WAI/APA/"
+    - name: 'ARIA: Accessible Rich Internet Applications <abbr title="Working Group">WG</abbr>'
+      url: "https://www.w3.org/WAI/ARIA/"
+    - name: 'EOWG: Education and Outreach <abbr title="Working Group">WG</abbr>'
+      url: "/about/groups/eowg/"
+      pages:
+      - name: Charter
+        url: "/EO/charter-current"
+      - name: Participate (Join)
+        url: "/about/groups/eowg/participate/"
+      - name: Current Participants
+        url: "https://www.w3.org/groups/wg/eowg/participants"
+    - name: 'WAI IG: WAI Interest Group'
+      url: "/about/groups/waiig/"
+    - name: 'Group Task Forces'
+      url: "/about/groups/taskforces/"
+  - name: Translating
+    url: "/about/translating/"
+  - name: Sponsoring
+    url: "/about/sponsoring/"
+  - name: Contacting
+    url: "/about/contacting/"
+  - name: Projects
+    url: "/about/projects/"
+    pages:
+    - name: WAI-CooP
+      url: "/about/projects/wai-coop/"
+      pages:
+      - name: Research Symposium 2021
+        url: "/about/projects/wai-coop/symposium1/"
+      - name: Research Symposium AI
+        url: "/about/projects/wai-coop/symposium2/"
+    - name: WAI-Guide
+      url: "/about/projects/wai-guide/"
+    - name: WAI-Tools
+      url: "/about/projects/wai-tools/"
+      pages:
+      - name: Final Open Meeting
+        url: "/about/projects/wai-tools/final-open-meeting/"
+      - name: Video Recording 1
+        url: "/about/projects/wai-tools/session1/"
+      - name: Video Recording 2
+        url: "/about/projects/wai-tools/session2/"
+      - name: Video Recording 3
+        url: "/about/projects/wai-tools/session3/"
+      - name: Video Recording 4
+        url: "/about/projects/wai-tools/session4/"
+      - name: Video Recording 5
+        url: "/about/projects/wai-tools/session5/"
+      - name: Third Open Meeting
+        url: "/about/projects/wai-tools/third-open-meeting/"
+      - name: Second Open Meeting
+        url: "/about/projects/wai-tools/second-open-meeting/"
+      - name: Online Symposium
+        url: "/about/projects/wai-tools/symposium/"
+        pages:
+        - name: Record
+          url: "/about/projects/wai-tools/symposium/record/"
+      - name: First Open Meeting
+        url: "/about/projects/wai-tools/first-open-meeting/"
+    - name: WAI Expanding Access
+      url: "/expand-access/"
+    - name: Easy Reading
+      url: "/about/projects/easy-reading/"
+    - name: WAI-Core 2015, 2020
+      url: "/about/projects/wai-core-2015/"
+    - name: WAI-Core Ford
+      url: "/about/projects/wai-core-ford/"
+  - name: Accessibility Statement
+    url: "/about/accessibility-statement/"
+  - name: Using WAI Material
+    url: "/about/using-wai-material/"
+- name: Resources
+  url: "/resources/"
+  mainnav: false
+- name: Cognitive Accessibility Guidance - Here in March 2022
+  url: "/WCAG2/supplemental/"
+  mainnav: false

--- a/content/index.md
+++ b/content/index.md
@@ -40,17 +40,17 @@ inline_css: |
   
 ---
 
-The following resources provide information for getting started with accessibility:
+The following resources provide information for **getting started with accessibility**:
 
 [[Introduction to Web Accessibility]](/fundamentals/accessibility-intro/)
 :   Introduces web accessibility and links to additional resources. Includes accessibility in context; why accessibility is important for individuals, businesses, society; making digital technology accessible; evaluating accessibility; and basic examples.
-    -   [Video Introduction to Web Accessibility and W3C Standards](/videos/standards-and-benefits/) 4-minute (% include image.html src="video.svg" alt="video" class="icon onright" %}
+    -   [Video Introduction to Web Accessibility and W3C Standards](/videos/standards-and-benefits/) 4-minute ({% include image.html src="video.svg" alt="video" class="icon onright" %}
     
 [[Accessibility: It's About People]](/people/)
 :   Explains the people aspect of accessibility and the role of accessibility in diversity, equality, and inclusion (DEI). Links to:
-    -   [Web Accessibility Perspectives: Explore the Impact and Benefits for Everyone](/perspective-videos/) - videos that demonstrate that web accessibility is essential for people with disabilities and useful for all. Ten 1-minute videos, or a 7-minute compliation (% include image.html src="video.svg" alt="video" class="icon onright" %}
+    -   [Web Accessibility Perspectives: Explore the Impact and Benefits for Everyone](/perspective-videos/) - videos that demonstrate that web accessibility is essential for people with disabilities and useful for all. Ten 1-minute videos, or a 7-minute compliation ({% include image.html src="video.svg" alt="video" class="icon onright" %}
     -   [[How People with Disabilities Use the Web]](/people-use-web/)
-    -   [Videos of How People with Disabilities Use the Web](/people-use-web/) Eighteen 2+minute videos, or 3 compliation (% include image.html src="video.svg" alt="video" class="icon onright" %}
+    -   [Videos of How People with Disabilities Use the Web](/people-use-web/) Eighteen 2+minute videos, or 3 compliation ({% include image.html src="video.svg" alt="video" class="icon onright" %}
     -   [[Older Users and Web Accessibility: Meeting the Needs of Ageing Web Users]](/older-users/), [Developing Websites for Older People: How Web Content Accessibility Guidelines (WCAG) 2.0 Applies](https://www.w3.org/WAI/older-users/developing/), [Web Accessibility for Older Users: A Literature Review](https://www.w3.org/WAI/older-users/literature/)
     -   [[Accessibility, Usability, and Inclusion]](/fundamentals/accessibility-usability-inclusion/)
 
@@ -60,19 +60,21 @@ The following resources provide information for getting started with accessibili
 [[Accessibility Principles]](/fundamentals/accessibility-principles/)
 :   A concise introduction to accessibility requirements for websites, apps, browsers, and other tools. It is organized similar to the WAI accessibility standards and provides a useful bridge to the standards. Read this page before reading the standards/guidelines.
 
-1. Digital Accessibility Courses
+Digital Accessibility Courses 1
 :   Links to:
     -   [[Digital Accessibility Foundations &mdash; Free Online Course]](/fundamentals/foundations-course/) - Introduces a self-paced course from W3C WAI for developers, designers, ux, writers, managers, advocates. **Designed for technical and non-technical learners**, including students, instructors, professionals, and people with disabilities. Course is free with optional certificate.
     -   [[Course List of Digital Accessibility Education, Training, and Certification]](/courses/list/) - Lists courses from different providers.
-
-2. Digital Accessibility Courses
-    -   [[Digital Accessibility Foundations &mdash; Free Online Course]](/fundamentals/foundations-course/) - Introduces a self-paced course from W3C WAI for developers, designers, ux, writers, managers, advocates. **Designed for technical and non-technical learners**, including students, instructors, professionals, and people with disabilities. Course is free with optional certificate.
-    -   [[Course List of Digital Accessibility Education, Training, and Certification]](/courses/list/) - Lists courses from different providers.
     
-3. Digital Accessibility Courses
+Digital Accessibility Courses 2
 :   -   [[Digital Accessibility Foundations &mdash; Free Online Course]](/fundamentals/foundations-course/) - Introduces a self-paced course from W3C WAI for developers, designers, ux, writers, managers, advocates. **Designed for technical and non-technical learners**, including students, instructors, professionals, and people with disabilities. Course is free with optional certificate.
     -   [[Course List of Digital Accessibility Education, Training, and Certification]](/courses/list/) - Lists courses from different providers.    
 
-A related page introduces existing guidelines and additional work on accessibility for people with cognitive and learning disabilities: [[Cognitive Accessibility at W3C]](/cognitive/).
+Digital Accessibility Courses 3
+    -   [[Digital Accessibility Foundations &mdash; Free Online Course]](/fundamentals/foundations-course/) - Introduces a self-paced course from W3C WAI for developers, designers, ux, writers, managers, advocates. **Designed for technical and non-technical learners**, including students, instructors, professionals, and people with disabilities. Course is free with optional certificate.
+    -   [[Course List of Digital Accessibility Education, Training, and Certification]](/courses/list/) - Lists courses from different providers.
+
+Related pages:
+* [Get Resources for ...](https://www.w3.org/WAI/roles/) links to resources for designers, developers, testers, managers, and more.
+* [[Cognitive Accessibility at W3C]](/cognitive/) introduces existing guidelines and additional work on accessibility for people with cognitive and learning disabilities.
 
 {% include image.html src="banner-with-blur.png" alt="" %}

--- a/content/index.md
+++ b/content/index.md
@@ -58,7 +58,7 @@ The following resources provide information for **getting started with accessibi
 [[Accessibility Principles]](/fundamentals/accessibility-principles/)
 :   A concise introduction to accessibility requirements for websites, apps, browsers, and other tools. It is organized similar to the WAI accessibility standards and provides a useful bridge to the standards. Read this page before reading the standards/guidelines.
 
-Digital Accessibility Courses 2
+Digital Accessibility Courses:
 :   -   [[Digital Accessibility Foundations &mdash; Free Online Course]](/fundamentals/foundations-course/) - Introduces a self-paced course from W3C WAI for developers, designers, ux, writers, managers, advocates. **Designed for technical and non-technical learners**, including students, instructors, professionals, and people with disabilities. Course is free with optional certificate.
     -   [[Course List of Digital Accessibility Education, Training, and Certification]](/courses/list/) - Lists courses from different providers.    
 

--- a/content/index.md
+++ b/content/index.md
@@ -48,7 +48,7 @@ The following resources provide information for **getting started with accessibi
 [[Accessibility: It's About People]](/people/)
 :   Explains the people aspect of accessibility and the role of accessibility in diversity, equality, and inclusion (DEI). Links to:
     -   [Web Accessibility Perspectives: Explore the Impact and Benefits for Everyone](/perspective-videos/) - videos that demonstrate that web accessibility is essential for people with disabilities and useful for all. Ten 1-minute videos, and a 7-minute compliation {% include image.html src="video.svg" alt="" class="icon" %}
-    -   [[How People with Disabilities Use the Web]](/people-use-web/), [Videos of How People with Disabilities Use the Web](/people-use-web/) Eighteen 2+minute videos, and 3 compliations {% include image.html src="video.svg" alt="" class="icon" %}
+    -   [[How People with Disabilities Use the Web]](/people-use-web/)<!-- , [Videos of How People with Disabilities Use the Web](/people-use-web/) Eighteen 2+minute videos, and 3 compliations {% include image.html src="video.svg" alt="" class="icon" %} -->
     -   [[Older Users and Web Accessibility: Meeting the Needs of Ageing Web Users]](/older-users/), [Developing Websites for Older People: How Web Content Accessibility Guidelines (WCAG) 2.0 Applies](https://www.w3.org/WAI/older-users/developing/), [Web Accessibility for Older Users: A Literature Review](https://www.w3.org/WAI/older-users/literature/)
     -   [[Accessibility, Usability, and Inclusion]](/fundamentals/accessibility-usability-inclusion/)
 

--- a/content/index.md
+++ b/content/index.md
@@ -34,6 +34,9 @@ footer: >
   <p><strong>Editor:</strong> <a href="https://www.w3.org/People/Shawn/">Shawn Lawton Henry</a>.</p>
   <p>Developed with input from the Education and Outreach Working Group (<a href="http://www.w3.org/WAI/EO/">EOWG</a>).</p>
 
+inline_css: |
+  img.icon {--img-width:1em}
+  
 ---
 
 The following resources provide information for getting started with accessibility:

--- a/content/index.md
+++ b/content/index.md
@@ -44,13 +44,13 @@ The following resources provide information for **getting started with accessibi
 
 [[Introduction to Web Accessibility]](/fundamentals/accessibility-intro/)
 :   Introduces web accessibility and links to additional resources. Includes accessibility in context; why accessibility is important for individuals, businesses, society; making digital technology accessible; evaluating accessibility; and basic examples.
-    -   [Video Introduction to Web Accessibility and W3C Standards](/videos/standards-and-benefits/) 4-minute ({% include image.html src="video.svg" alt="video" class="icon onright" %}
+    -   [Video Introduction to Web Accessibility and W3C Standards](/videos/standards-and-benefits/) 4-minute {% include image.html src="video.svg" alt="video" class="icon" %}
     
 [[Accessibility: It's About People]](/people/)
 :   Explains the people aspect of accessibility and the role of accessibility in diversity, equality, and inclusion (DEI). Links to:
-    -   [Web Accessibility Perspectives: Explore the Impact and Benefits for Everyone](/perspective-videos/) - videos that demonstrate that web accessibility is essential for people with disabilities and useful for all. Ten 1-minute videos, or a 7-minute compliation ({% include image.html src="video.svg" alt="video" class="icon onright" %}
+    -   [Web Accessibility Perspectives: Explore the Impact and Benefits for Everyone](/perspective-videos/) - videos that demonstrate that web accessibility is essential for people with disabilities and useful for all. Ten 1-minute videos, or a 7-minute compliation {% include image.html src="video.svg" alt="video" class="icon" %}
     -   [[How People with Disabilities Use the Web]](/people-use-web/)
-    -   [Videos of How People with Disabilities Use the Web](/people-use-web/) Eighteen 2+minute videos, or 3 compliation ({% include image.html src="video.svg" alt="video" class="icon onright" %}
+    -   [Videos of How People with Disabilities Use the Web](/people-use-web/) Eighteen 2+minute videos, or 3 compliations {% include image.html src="video.svg" alt="video" class="icon" %}
     -   [[Older Users and Web Accessibility: Meeting the Needs of Ageing Web Users]](/older-users/), [Developing Websites for Older People: How Web Content Accessibility Guidelines (WCAG) 2.0 Applies](https://www.w3.org/WAI/older-users/developing/), [Web Accessibility for Older Users: A Literature Review](https://www.w3.org/WAI/older-users/literature/)
     -   [[Accessibility, Usability, and Inclusion]](/fundamentals/accessibility-usability-inclusion/)
 

--- a/content/index.md
+++ b/content/index.md
@@ -61,8 +61,8 @@ The following resources provide information for getting started with accessibili
 
 Digital Accessibility Courses
 :   Links to:
-    -   [[Digital Accessibility Foundations &mdash; Free Online Course]](/fundamentals/foundations-course/) - introduces a self-paced course on web accessibility from W3C WAI for technical and non-technical learners.
-    -   [[Course List of Digital Accessibility Education, Training, and Certification]](/courses/list/) - lists courses from different providers.
+    -   [[Digital Accessibility Foundations &mdash; Free Online Course]](/fundamentals/foundations-course/) - Introduces a self-paced course from W3C WAI for developers, designers, ux, writers, managers, advocates. **Designed for technical and non-technical learners**, including students, instructors, professionals, and people with disabilities. Course is free with optional certificate.
+    -   [[Course List of Digital Accessibility Education, Training, and Certification]](/courses/list/) - Lists courses from different providers.
 
 A related page introduces existing guidelines and additional work on accessibility for people with cognitive and learning disabilities: [[Cognitive Accessibility at W3C]](/cognitive/).
 

--- a/content/index.md
+++ b/content/index.md
@@ -47,8 +47,8 @@ The following resources provide information for **getting started with accessibi
     
 [[Accessibility: It's About People]](/people/)
 :   Explains the people aspect of accessibility and the role of accessibility in diversity, equality, and inclusion (DEI). Links to:
-    -   [Web Accessibility Perspectives: Explore the Impact and Benefits for Everyone](/perspective-videos/) - videos that demonstrate that web accessibility is essential for people with disabilities and useful for all. Ten 1-minute videos, or a 7-minute compliation {% include image.html src="video.svg" alt="" class="icon" %}
-    -   [[How People with Disabilities Use the Web]](/people-use-web/), [Videos of How People with Disabilities Use the Web](/people-use-web/) Eighteen 2+minute videos, or 3 compliations {% include image.html src="video.svg" alt="" class="icon" %}
+    -   [Web Accessibility Perspectives: Explore the Impact and Benefits for Everyone](/perspective-videos/) - videos that demonstrate that web accessibility is essential for people with disabilities and useful for all. Ten 1-minute videos, and a 7-minute compliation {% include image.html src="video.svg" alt="" class="icon" %}
+    -   [[How People with Disabilities Use the Web]](/people-use-web/), [Videos of How People with Disabilities Use the Web](/people-use-web/) Eighteen 2+minute videos, and 3 compliations {% include image.html src="video.svg" alt="" class="icon" %}
     -   [[Older Users and Web Accessibility: Meeting the Needs of Ageing Web Users]](/older-users/), [Developing Websites for Older People: How Web Content Accessibility Guidelines (WCAG) 2.0 Applies](https://www.w3.org/WAI/older-users/developing/), [Web Accessibility for Older Users: A Literature Review](https://www.w3.org/WAI/older-users/literature/)
     -   [[Accessibility, Usability, and Inclusion]](/fundamentals/accessibility-usability-inclusion/)
 

--- a/content/index.md
+++ b/content/index.md
@@ -6,7 +6,7 @@ title: "Accessibility Fundamentals Overview"
 nav_title: "Overview" 
 
 lang: en   # Change "en" to the translated-language shortcode from https://www.iana.org/assignments/language-subtag-registry/language-subtag-registry
-last_updated: 2021-05-13   # Put the date of this translation YYYY-MM-DD (with month in the middle)
+last_updated: 2023-01-23   # Put the date of this translation YYYY-MM-DD (with month in the middle)
 
 # translators:    # remove from the beginning of this line and the lines below: "# " (the hash sign and the space)
 # - name: "Jan Doe"   # Replace Jan Doe with translator name
@@ -30,7 +30,7 @@ feedbackmail: wai@w3.org
 # Translate the Working Group name. Leave the Working Group acronym in English.
 # Do not change the dates in the footer below.
 footer: >
-  <p><strong>Date:</strong> Updated 13 May 2021. CHANGELOG.</p>
+  <p><strong>Date:</strong> Updated 23 January 2023. CHANGELOG.</p>
   <p><strong>Editor:</strong> <a href="https://www.w3.org/People/Shawn/">Shawn Lawton Henry</a>.</p>
   <p>Developed with input from the Education and Outreach Working Group (<a href="http://www.w3.org/WAI/EO/">EOWG</a>).</p>
 
@@ -39,30 +39,28 @@ footer: >
 The following resources provide information for getting started with accessibility:
 
 [[Introduction to Web Accessibility]](/fundamentals/accessibility-intro/)
-:   Introduces web accessibility and links to additional resources.
-    -   [[Video Introduction to Web Accessibility and W3C Standards]](/videos/standards-and-benefits/) 4-minute video.
-
-[[Digital Accessibility Foundations &mdash; Free Online Course]](/fundamentals/foundations-course/)
-:   Introduces a self-paced course from W3C WAI for technical and non-technical learners.
+:   Introduces web accessibility and links to additional resources. Includes accessibility in context; why accessibility is important for individuals, businesses, society; making digital technology accessible; evaluating accessibility; and basic examples.
+    -   [{% include image.html src="video.svg" alt="video" class="icon" %} Video Introduction to Web Accessibility and W3C Standards](/videos/standards-and-benefits/) 4-minute video.
+    
+[[Accessibility: It's About People]](/people/)
+:   Explains the people aspect of accessibility and the role of accessibility in diversity, equality, and inclusion (DEI). Links to:
+    -   [{% include image.html src="video.svg" alt="video" class="icon" %} Web Accessibility Perspectives: Explore the Impact and Benefits for Everyone](/perspective-videos/) - videos that demonstrate that web accessibility is essential for people with disabilities and useful for all.
+    -   [[How People with Disabilities Use the Web]](/people-use-web/)
+    -   [{% include image.html src="video.svg" alt="video" class="icon" %} Videos of How People with Disabilities Use the Web](/people-use-web/)
+    -   [[Older Users and Web Accessibility: Meeting the Needs of Ageing Web Users]](/older-users/), [Developing Websites for Older People: How Web Content Accessibility Guidelines (WCAG) 2.0 Applies](https://www.w3.org/WAI/older-users/developing/), [Web Accessibility for Older Users: A Literature Review](https://www.w3.org/WAI/older-users/literature/)
+    -   [[Accessibility, Usability, and Inclusion]](/fundamentals/accessibility-usability-inclusion/)
 
 [[Essential Components of Web Accessibility]](/fundamentals/components/)
-:   Shows how web accessibility depends on several components of web development and interaction working together and shows the relationship between the WAI guidelines: Web Content Accessibility Guidelines ([WCAG](/standards-guidelines/wcag/)), Authoring Tool Accessibility Guidelines ([ATAG](/standards-guidelines/atag/)), and User Agent Accessibility Guidelines ([UAAG](/standards-guidelines/uaag/)).
+:   Shows how web accessibility depends on several components of web development and interaction working together and shows the relationship between the WAI guidelines and other standards.
 
 [[Accessibility Principles]](/fundamentals/accessibility-principles/)
-:   Helps developers, designers, and others to understand the principles  for creating accessible websites, web applications, browsers, and other web tools. Provides references to the international standards from W3C Web Accessibility Initiative (WAI) and to [stories of web users](/people-use-web/user-stories/).
+:   A concise introduction to accessibility requirements for websites, apps, browsers, and other tools. It is organized similar to the WAI accessibility standards and provides a useful bridge to the standards. Read this page before reading the standards/guidelines.
 
-[[Web Accessibility Perspectives: Explore the Impact and Benefits for Everyone]](/perspective-videos/)
-:   **Videos** that demonstrate that web accessibility is essential for people with disabilities and useful for all. Learn about the impact of accessibility and the benefits for everyone in a variety of situations. Each video is about 1 minute, and the [compilation](https://www.youtube.com/watch?v=3f31oufqFSM) is 7:37. Pages include supporting information.
-
-[[How People with Disabilities Use the Web]](/people-use-web/)
-:   Introduces how people with disabilities use the web. Describes tools and approaches that people with different kinds of disabilities use to browse the web and the barriers they encounter due to poor design.
-
-[[Older Users and Web Accessibility: Meeting the Needs of Ageing Web Users]](/older-users/)
-:   Explains that designing products that are easier for older people to use is similar to designing for people with disabilities. Guidance on how to make your websites, web applications, and web tools work better for older users is covered in existing international accessibility standards from the W3C, including Web Content Accessibility Guidelines (WCAG).
-    -   [Developing Websites for Older People: How Web Content Accessibility Guidelines (WCAG) 2.0 Applies](https://www.w3.org/WAI/older-users/developing/)
-    -   [Web Accessibility for Older Users: A Literature Review](https://www.w3.org/WAI/older-users/literature/)
-
-[[Accessibility, Usability, and Inclusion]](/fundamentals/accessibility-usability-inclusion/)
-:   Explains the distinctions and overlaps between accessibility, usability, and inclusive design; encourages increased coordination across research and practice in these disciplines; and points out the importance of maintaining the focus of accessibility on people with disabilities.
+Digital Accessibility Courses
+:   Links to:
+    -   [[Digital Accessibility Foundations &mdash; Free Online Course]](/fundamentals/foundations-course/) - introduces a self-paced course on web accessibility from W3C WAI for technical and non-technical learners.
+    -   [[Course List of Digital Accessibility Education, Training, and Certification]](/courses/list/) - lists courses from different providers.
 
 A related page introduces existing guidelines and additional work on accessibility for people with cognitive and learning disabilities: [[Cognitive Accessibility at W3C]](/cognitive/).
+
+{% include image.html src="banner-with-blur.png" alt="" %}

--- a/content/index.md
+++ b/content/index.md
@@ -36,7 +36,6 @@ footer: >
 
 inline_css: |
   img.icon {--img-width:1em}
-  img.icon.onright {margin-left:7px}
   
 ---
 
@@ -44,13 +43,12 @@ The following resources provide information for **getting started with accessibi
 
 [[Introduction to Web Accessibility]](/fundamentals/accessibility-intro/)
 :   Introduces web accessibility and links to additional resources. Includes accessibility in context; why accessibility is important for individuals, businesses, society; making digital technology accessible; evaluating accessibility; and basic examples.
-    -   [Video Introduction to Web Accessibility and W3C Standards](/videos/standards-and-benefits/) 4-minute {% include image.html src="video.svg" alt="video" class="icon" %}
+    -   [Video Introduction to Web Accessibility and W3C Standards](/videos/standards-and-benefits/) 4-minutes {% include image.html src="video.svg" alt="" class="icon" %}
     
 [[Accessibility: It's About People]](/people/)
 :   Explains the people aspect of accessibility and the role of accessibility in diversity, equality, and inclusion (DEI). Links to:
-    -   [Web Accessibility Perspectives: Explore the Impact and Benefits for Everyone](/perspective-videos/) - videos that demonstrate that web accessibility is essential for people with disabilities and useful for all. Ten 1-minute videos, or a 7-minute compliation {% include image.html src="video.svg" alt="video" class="icon" %}
-    -   [[How People with Disabilities Use the Web]](/people-use-web/)
-    -   [Videos of How People with Disabilities Use the Web](/people-use-web/) Eighteen 2+minute videos, or 3 compliations {% include image.html src="video.svg" alt="video" class="icon" %}
+    -   [Web Accessibility Perspectives: Explore the Impact and Benefits for Everyone](/perspective-videos/) - videos that demonstrate that web accessibility is essential for people with disabilities and useful for all. Ten 1-minute videos, or a 7-minute compliation {% include image.html src="video.svg" alt="" class="icon" %}
+    -   [[How People with Disabilities Use the Web]](/people-use-web/), [Videos of How People with Disabilities Use the Web](/people-use-web/) Eighteen 2+minute videos, or 3 compliations {% include image.html src="video.svg" alt="" class="icon" %}
     -   [[Older Users and Web Accessibility: Meeting the Needs of Ageing Web Users]](/older-users/), [Developing Websites for Older People: How Web Content Accessibility Guidelines (WCAG) 2.0 Applies](https://www.w3.org/WAI/older-users/developing/), [Web Accessibility for Older Users: A Literature Review](https://www.w3.org/WAI/older-users/literature/)
     -   [[Accessibility, Usability, and Inclusion]](/fundamentals/accessibility-usability-inclusion/)
 
@@ -60,21 +58,10 @@ The following resources provide information for **getting started with accessibi
 [[Accessibility Principles]](/fundamentals/accessibility-principles/)
 :   A concise introduction to accessibility requirements for websites, apps, browsers, and other tools. It is organized similar to the WAI accessibility standards and provides a useful bridge to the standards. Read this page before reading the standards/guidelines.
 
-Digital Accessibility Courses 1
-:   Links to:
-    -   [[Digital Accessibility Foundations &mdash; Free Online Course]](/fundamentals/foundations-course/) - Introduces a self-paced course from W3C WAI for developers, designers, ux, writers, managers, advocates. **Designed for technical and non-technical learners**, including students, instructors, professionals, and people with disabilities. Course is free with optional certificate.
-    -   [[Course List of Digital Accessibility Education, Training, and Certification]](/courses/list/) - Lists courses from different providers.
-    
 Digital Accessibility Courses 2
 :   -   [[Digital Accessibility Foundations &mdash; Free Online Course]](/fundamentals/foundations-course/) - Introduces a self-paced course from W3C WAI for developers, designers, ux, writers, managers, advocates. **Designed for technical and non-technical learners**, including students, instructors, professionals, and people with disabilities. Course is free with optional certificate.
     -   [[Course List of Digital Accessibility Education, Training, and Certification]](/courses/list/) - Lists courses from different providers.    
 
-Digital Accessibility Courses 3
-    -   [[Digital Accessibility Foundations &mdash; Free Online Course]](/fundamentals/foundations-course/) - Introduces a self-paced course from W3C WAI for developers, designers, ux, writers, managers, advocates. **Designed for technical and non-technical learners**, including students, instructors, professionals, and people with disabilities. Course is free with optional certificate.
-    -   [[Course List of Digital Accessibility Education, Training, and Certification]](/courses/list/) - Lists courses from different providers.
-
-Related pages:
-* [Get Resources for ...](https://www.w3.org/WAI/roles/) links to resources for designers, developers, testers, managers, and more.
-* [[Cognitive Accessibility at W3C]](/cognitive/) introduces existing guidelines and additional work on accessibility for people with cognitive and learning disabilities.
+Related page: [Get Resources for ...](https://www.w3.org/WAI/roles/) links to resources for designers, developers, testers, managers, and more.
 
 {% include image.html src="banner-with-blur.png" alt="" %}

--- a/content/index.md
+++ b/content/index.md
@@ -30,12 +30,13 @@ feedbackmail: wai@w3.org
 # Translate the Working Group name. Leave the Working Group acronym in English.
 # Do not change the dates in the footer below.
 footer: >
-  <p><strong>Date:</strong> Updated 23 January 2023. CHANGELOG.</p>
+  <p><strong>Date:</strong> Updated 3 March 2023. CHANGELOG.</p>
   <p><strong>Editor:</strong> <a href="https://www.w3.org/People/Shawn/">Shawn Lawton Henry</a>.</p>
   <p>Developed with input from the Education and Outreach Working Group (<a href="http://www.w3.org/WAI/EO/">EOWG</a>).</p>
 
 inline_css: |
   img.icon {--img-width:1em}
+  img.icon.onright {margin-left:7px}
   
 ---
 
@@ -43,13 +44,13 @@ The following resources provide information for getting started with accessibili
 
 [[Introduction to Web Accessibility]](/fundamentals/accessibility-intro/)
 :   Introduces web accessibility and links to additional resources. Includes accessibility in context; why accessibility is important for individuals, businesses, society; making digital technology accessible; evaluating accessibility; and basic examples.
-    -   [{% include image.html src="video.svg" alt="video" class="icon" %} Video Introduction to Web Accessibility and W3C Standards](/videos/standards-and-benefits/) 4-minute video.
+    -   [Video Introduction to Web Accessibility and W3C Standards](/videos/standards-and-benefits/) 4-minute (% include image.html src="video.svg" alt="video" class="icon onright" %}
     
 [[Accessibility: It's About People]](/people/)
 :   Explains the people aspect of accessibility and the role of accessibility in diversity, equality, and inclusion (DEI). Links to:
-    -   [{% include image.html src="video.svg" alt="video" class="icon" %} Web Accessibility Perspectives: Explore the Impact and Benefits for Everyone](/perspective-videos/) - videos that demonstrate that web accessibility is essential for people with disabilities and useful for all.
+    -   [Web Accessibility Perspectives: Explore the Impact and Benefits for Everyone](/perspective-videos/) - videos that demonstrate that web accessibility is essential for people with disabilities and useful for all. Ten 1-minute videos, or a 7-minute compliation (% include image.html src="video.svg" alt="video" class="icon onright" %}
     -   [[How People with Disabilities Use the Web]](/people-use-web/)
-    -   [{% include image.html src="video.svg" alt="video" class="icon" %} Videos of How People with Disabilities Use the Web](/people-use-web/)
+    -   [Videos of How People with Disabilities Use the Web](/people-use-web/) Eighteen 2+minute videos, or 3 compliation (% include image.html src="video.svg" alt="video" class="icon onright" %}
     -   [[Older Users and Web Accessibility: Meeting the Needs of Ageing Web Users]](/older-users/), [Developing Websites for Older People: How Web Content Accessibility Guidelines (WCAG) 2.0 Applies](https://www.w3.org/WAI/older-users/developing/), [Web Accessibility for Older Users: A Literature Review](https://www.w3.org/WAI/older-users/literature/)
     -   [[Accessibility, Usability, and Inclusion]](/fundamentals/accessibility-usability-inclusion/)
 
@@ -59,10 +60,18 @@ The following resources provide information for getting started with accessibili
 [[Accessibility Principles]](/fundamentals/accessibility-principles/)
 :   A concise introduction to accessibility requirements for websites, apps, browsers, and other tools. It is organized similar to the WAI accessibility standards and provides a useful bridge to the standards. Read this page before reading the standards/guidelines.
 
-Digital Accessibility Courses
+1. Digital Accessibility Courses
 :   Links to:
     -   [[Digital Accessibility Foundations &mdash; Free Online Course]](/fundamentals/foundations-course/) - Introduces a self-paced course from W3C WAI for developers, designers, ux, writers, managers, advocates. **Designed for technical and non-technical learners**, including students, instructors, professionals, and people with disabilities. Course is free with optional certificate.
     -   [[Course List of Digital Accessibility Education, Training, and Certification]](/courses/list/) - Lists courses from different providers.
+
+2. Digital Accessibility Courses
+    -   [[Digital Accessibility Foundations &mdash; Free Online Course]](/fundamentals/foundations-course/) - Introduces a self-paced course from W3C WAI for developers, designers, ux, writers, managers, advocates. **Designed for technical and non-technical learners**, including students, instructors, professionals, and people with disabilities. Course is free with optional certificate.
+    -   [[Course List of Digital Accessibility Education, Training, and Certification]](/courses/list/) - Lists courses from different providers.
+    
+3. Digital Accessibility Courses
+:   -   [[Digital Accessibility Foundations &mdash; Free Online Course]](/fundamentals/foundations-course/) - Introduces a self-paced course from W3C WAI for developers, designers, ux, writers, managers, advocates. **Designed for technical and non-technical learners**, including students, instructors, professionals, and people with disabilities. Course is free with optional certificate.
+    -   [[Course List of Digital Accessibility Education, Training, and Certification]](/courses/list/) - Lists courses from different providers.    
 
 A related page introduces existing guidelines and additional work on accessibility for people with cognitive and learning disabilities: [[Cognitive Accessibility at W3C]](/cognitive/).
 

--- a/content/people.md
+++ b/content/people.md
@@ -43,11 +43,11 @@ Many WAI resources cover the organizational, technical, and standards aspects of
 </div>
 
 [Web Accessibility Perspectives: Explore the Impact and Benefits for Everyone](/perspective-videos/) 
-:   Videos that demonstrate that web accessibility is **_essential for people with disabilities and useful for all_**. Learn about the impact of accessibility and the benefits for everyone in a variety of situations. Pages include supporting information. Ten 1-minute videos, or a 7-minute compilation {% include image.html src="video.svg" alt="" class="icon" %}
+:   Videos that demonstrate that web accessibility is **_essential for people with disabilities and useful for all_**. Learn about the impact of accessibility and the benefits for everyone in a variety of situations. Pages include supporting information. Ten 1-minute videos, and a 7-minute compilation {% include image.html src="video.svg" alt="" class="icon" %}
 
 [[How People with Disabilities Use the Web]](/people-use-web/)
 :   Introduces how people with disabilities use the web. Describes tools and approaches that people with different kinds of disabilities use to browse the web and the barriers they encounter due to poor design.
-    -   [Videos of How People with Disabilities Use the Web](/people-use-web/) show stories of disabled people using the web; diverse abilities and barriers; and tools and techniques for using digital technology. Eighteen 2+minute videos, or 3 compliations {% include image.html src="video.svg" alt="" class="icon" %}
+    -   [Videos of How People with Disabilities Use the Web](/people-use-web/) show stories of disabled people using the web; diverse abilities and barriers; and tools and techniques for using digital technology. Eighteen 2+minute videos, and 3 compliations {% include image.html src="video.svg" alt="" class="icon" %}
 
 [[Older Users and Web Accessibility: Meeting the Needs of Ageing Web Users]](/older-users/)
 :   Explains that designing products that are easier for older people to use is similar to designing for people with disabilities. Guidance on how to make your websites, web applications, and web tools work better for older users is covered in existing international accessibility standards from the W3C, including Web Content Accessibility Guidelines (WCAG).

--- a/content/people.md
+++ b/content/people.md
@@ -43,7 +43,7 @@ Many WAI resources cover the organizational, technical, and standards aspects of
 </div>
 
 [Web Accessibility Perspectives: Explore the Impact and Benefits for Everyone](/perspective-videos/) 
-:   Videos that demonstrate that web accessibility is **_essential for people with disabilities and useful for all_**. Learn about the impact of accessibility and the benefits for everyone in a variety of situations. Pages include supporting information. Ten 1-minute videos, or a 7-minute [compilation](https://www.youtube.com/watch?v=3f31oufqFSM) {% include image.html src="video.svg" alt="" class="icon" %}
+:   Videos that demonstrate that web accessibility is **_essential for people with disabilities and useful for all_**. Learn about the impact of accessibility and the benefits for everyone in a variety of situations. Pages include supporting information. Ten 1-minute videos, or a 7-minute compilation {% include image.html src="video.svg" alt="" class="icon" %}
 
 [[How People with Disabilities Use the Web]](/people-use-web/)
 :   Introduces how people with disabilities use the web. Describes tools and approaches that people with different kinds of disabilities use to browse the web and the barriers they encounter due to poor design.

--- a/content/people.md
+++ b/content/people.md
@@ -44,11 +44,11 @@ Many WAI resources cover the organizational, technical, and standards aspects of
 </div>
 
 [Web Accessibility Perspectives: Explore the Impact and Benefits for Everyone](/perspective-videos/) 
-:   Videos that demonstrate that web accessibility is **_essential for people with disabilities and useful for all_**. Learn about the impact of accessibility and the benefits for everyone in a variety of situations. Pages include supporting information. Ten 1-minute videos, or a 7-minute [compilation](https://www.youtube.com/watch?v=3f31oufqFSM) (% include image.html src="video.svg" alt="video" class="icon onright" %})
+:   Videos that demonstrate that web accessibility is **_essential for people with disabilities and useful for all_**. Learn about the impact of accessibility and the benefits for everyone in a variety of situations. Pages include supporting information. Ten 1-minute videos, or a 7-minute [compilation](https://www.youtube.com/watch?v=3f31oufqFSM) {% include image.html src="video.svg" alt="video" class="icon onright" %}
 
 [[How People with Disabilities Use the Web]](/people-use-web/)
 :   Introduces how people with disabilities use the web. Describes tools and approaches that people with different kinds of disabilities use to browse the web and the barriers they encounter due to poor design.
-    -   [Videos of How People with Disabilities Use the Web](/people-use-web/) show stories of disabled people using the web; diverse abilities and barriers; and tools and techniques for using digital technology. Eighteen 2+minute videos, or 3 compliation (% include image.html src="video.svg" alt="video" class="icon onright" %}
+    -   [Videos of How People with Disabilities Use the Web](/people-use-web/) show stories of disabled people using the web; diverse abilities and barriers; and tools and techniques for using digital technology. Eighteen 2+minute videos, or 3 compliation {% include image.html src="video.svg" alt="video" class="icon onright" %}
 
 [[Older Users and Web Accessibility: Meeting the Needs of Ageing Web Users]](/older-users/)
 :   Explains that designing products that are easier for older people to use is similar to designing for people with disabilities. Guidance on how to make your websites, web applications, and web tools work better for older users is covered in existing international accessibility standards from the W3C, including Web Content Accessibility Guidelines (WCAG).

--- a/content/people.md
+++ b/content/people.md
@@ -46,10 +46,7 @@ Many WAI resources cover the organizational, technical, and standards aspects of
 :   Videos that demonstrate that web accessibility is **_essential for people with disabilities and useful for all_**. Learn about the impact of accessibility and the benefits for everyone in a variety of situations. Pages include supporting information. Ten 1-minute videos, and a 7-minute compilation {% include image.html src="video.svg" alt="" class="icon" %}
 
 [[How People with Disabilities Use the Web]](/people-use-web/)
-:   Introduces how people with disabilities use the web. Describes tools and approaches that people with different kinds of disabilities use to browse the web and the barriers they encounter due to poor design.
-<!--
-    -   [Videos of How People with Disabilities Use the Web](/people-use-web/) show stories of disabled people using the web; diverse abilities and barriers; and tools and techniques for using digital technology. Eighteen 2+minute videos, and 3 compliations {% include image.html src="video.svg" alt="" class="icon" %}
--->
+:   Introduces how people with disabilities use the web. Describes tools and approaches that people with different kinds of disabilities use to browse the web and the barriers they encounter due to poor design. <!-- @@sub-bullet: [Videos of How People with Disabilities Use the Web](/people-use-web/) links to eighteen 2+minute videos, and 3 compliations {% include image.html src="video.svg" alt="" class="icon" %} -->
 
 [[Older Users and Web Accessibility: Meeting the Needs of Ageing Web Users]](/older-users/)
 :   Explains that designing products that are easier for older people to use is similar to designing for people with disabilities. Guidance on how to make your websites, web applications, and web tools work better for older users is covered in existing international accessibility standards from the W3C, including Web Content Accessibility Guidelines (WCAG).

--- a/content/people.md
+++ b/content/people.md
@@ -17,13 +17,13 @@ description: Videos, personas, and user stories of how people with disabilities 
 
 feedbackmail: wai@w3.org
 footer: > # Text in footer in HTML
-  <p><strong>Date:</strong> Updated 6 January 2023.</p>
+  <p><strong>Date:</strong> Updated 3 March 2023.</p>
   <p><strong>Editor:</strong> <a href="https://www.w3.org/People/Shawn/">Shawn Lawton Henry</a>.</p>
   <p>Developed with input from the Education and Outreach Working Group (<a href="https://www.w3.org/groups/wg/eowg">EOWG</a>). Developed as part of the <a href="https://www.w3.org/WAI/about/projects/wai-guide">WAI-Guide project</a>, co-funded by the European Commission.</p>
   
 inline_css: |
   img.icon {--img-width:1em}
-  img.icon.onright {margin-left:3px}
+  img.icon.onright {margin-left:7px}
 
 ---
 
@@ -43,12 +43,12 @@ Many WAI resources cover the organizational, technical, and standards aspects of
 {% include image.html src="mobile-outside.png" alt="" class="mini" %}
 </div>
 
-[Web Accessibility Perspectives: Explore the Impact and Benefits for Everyone](/perspective-videos/) ({% include image.html src="video.svg" alt="video" class="icon onright" %} 10 short videos)
-:   Videos that demonstrate that web accessibility is **_essential for people with disabilities and useful for all_**. Learn about the impact of accessibility and the benefits for everyone in a variety of situations. Each video is about 1 minute, and the [compilation](https://www.youtube.com/watch?v=3f31oufqFSM) is 7:37. Pages include supporting information.
+[Web Accessibility Perspectives: Explore the Impact and Benefits for Everyone](/perspective-videos/) 
+:   Videos that demonstrate that web accessibility is **_essential for people with disabilities and useful for all_**. Learn about the impact of accessibility and the benefits for everyone in a variety of situations. Pages include supporting information. Ten 1-minute videos, or a 7-minute [compilation](https://www.youtube.com/watch?v=3f31oufqFSM) (% include image.html src="video.svg" alt="video" class="icon onright" %})
 
 [[How People with Disabilities Use the Web]](/people-use-web/)
 :   Introduces how people with disabilities use the web. Describes tools and approaches that people with different kinds of disabilities use to browse the web and the barriers they encounter due to poor design.
-<!--    -   [Videos of How People with Disabilities Use the Web](/people-use-web/) ({% include image.html src="video.svg" class="icon onright" %} 18 short videos) show stories of disabled people using the web; diverse abilities and barriers; and tools and techniques for using digital technology.
+    -   [Videos of How People with Disabilities Use the Web](/people-use-web/) show stories of disabled people using the web; diverse abilities and barriers; and tools and techniques for using digital technology. Eighteen 2+minute videos, or 3 compliation (% include image.html src="video.svg" alt="video" class="icon onright" %}
 
 [[Older Users and Web Accessibility: Meeting the Needs of Ageing Web Users]](/older-users/)
 :   Explains that designing products that are easier for older people to use is similar to designing for people with disabilities. Guidance on how to make your websites, web applications, and web tools work better for older users is covered in existing international accessibility standards from the W3C, including Web Content Accessibility Guidelines (WCAG).

--- a/content/people.md
+++ b/content/people.md
@@ -23,7 +23,6 @@ footer: > # Text in footer in HTML
   
 inline_css: |
   img.icon {--img-width:1em}
-  img.icon.onright {margin-left:7px}
 
 ---
 
@@ -44,11 +43,11 @@ Many WAI resources cover the organizational, technical, and standards aspects of
 </div>
 
 [Web Accessibility Perspectives: Explore the Impact and Benefits for Everyone](/perspective-videos/) 
-:   Videos that demonstrate that web accessibility is **_essential for people with disabilities and useful for all_**. Learn about the impact of accessibility and the benefits for everyone in a variety of situations. Pages include supporting information. Ten 1-minute videos, or a 7-minute [compilation](https://www.youtube.com/watch?v=3f31oufqFSM) {% include image.html src="video.svg" alt="video" class="icon onright" %}
+:   Videos that demonstrate that web accessibility is **_essential for people with disabilities and useful for all_**. Learn about the impact of accessibility and the benefits for everyone in a variety of situations. Pages include supporting information. Ten 1-minute videos, or a 7-minute [compilation](https://www.youtube.com/watch?v=3f31oufqFSM) {% include image.html src="video.svg" alt="" class="icon" %}
 
 [[How People with Disabilities Use the Web]](/people-use-web/)
 :   Introduces how people with disabilities use the web. Describes tools and approaches that people with different kinds of disabilities use to browse the web and the barriers they encounter due to poor design.
-    -   [Videos of How People with Disabilities Use the Web](/people-use-web/) show stories of disabled people using the web; diverse abilities and barriers; and tools and techniques for using digital technology. Eighteen 2+minute videos, or 3 compliation {% include image.html src="video.svg" alt="video" class="icon onright" %}
+    -   [Videos of How People with Disabilities Use the Web](/people-use-web/) show stories of disabled people using the web; diverse abilities and barriers; and tools and techniques for using digital technology. Eighteen 2+minute videos, or 3 compliations {% include image.html src="video.svg" alt="" class="icon" %}
 
 [[Older Users and Web Accessibility: Meeting the Needs of Ageing Web Users]](/older-users/)
 :   Explains that designing products that are easier for older people to use is similar to designing for people with disabilities. Guidance on how to make your websites, web applications, and web tools work better for older users is covered in existing international accessibility standards from the W3C, including Web Content Accessibility Guidelines (WCAG).

--- a/content/people.md
+++ b/content/people.md
@@ -47,7 +47,9 @@ Many WAI resources cover the organizational, technical, and standards aspects of
 
 [[How People with Disabilities Use the Web]](/people-use-web/)
 :   Introduces how people with disabilities use the web. Describes tools and approaches that people with different kinds of disabilities use to browse the web and the barriers they encounter due to poor design.
+<!--
     -   [Videos of How People with Disabilities Use the Web](/people-use-web/) show stories of disabled people using the web; diverse abilities and barriers; and tools and techniques for using digital technology. Eighteen 2+minute videos, and 3 compliations {% include image.html src="video.svg" alt="" class="icon" %}
+-->
 
 [[Older Users and Web Accessibility: Meeting the Needs of Ageing Web Users]](/older-users/)
 :   Explains that designing products that are easier for older people to use is similar to designing for people with disabilities. Guidance on how to make your websites, web applications, and web tools work better for older users is covered in existing international accessibility standards from the W3C, including Web Content Accessibility Guidelines (WCAG).

--- a/content/people.md
+++ b/content/people.md
@@ -58,5 +58,6 @@ Many WAI resources cover the organizational, technical, and standards aspects of
 [[Accessibility, Usability, and Inclusion]](/fundamentals/accessibility-usability-inclusion/)
 :   Explains the distinctions and overlaps between accessibility, usability, and inclusive design; encourages increased coordination across research and practice in these disciplines; and points out the importance of maintaining the focus of accessibility on people with disabilities.
 
-Related resource:
+Related resources:
+- **[[Cognitive Accessibility at W3C]](/cognitive/)** introduces existing guidelines and additional work on accessibility for people with cognitive and learning disabilities.
 - **[[Involving Users in Web Projects for Better, Easier Accessibility]](/planning/involving-users/)** describes how project managers, designers, and developers can better understand accessibility issues and implement more effective accessibility solutions.

--- a/content/people.md
+++ b/content/people.md
@@ -47,8 +47,7 @@ Many WAI resources cover the organizational, technical, and standards aspects of
 
 [[How People with Disabilities Use the Web]](/people-use-web/)
 :   Introduces how people with disabilities use the web. Describes tools and approaches that people with different kinds of disabilities use to browse the web and the barriers they encounter due to poor design.
-<!--    -   [{% include image.html src="video.svg" alt="video" class="icon" %} Videos of How People with Disabilities Use the Web](/people-use-web/) video series showing stories of disabled people using the web; diverse abilities and barriers; and tools and techniques for using digital technology.
--->
+    -   [{% include image.html src="video.svg" alt="video" class="icon" %} Videos of How People with Disabilities Use the Web](/people-use-web/) video series showing stories of disabled people using the web; diverse abilities and barriers; and tools and techniques for using digital technology.
 
 [[Older Users and Web Accessibility: Meeting the Needs of Ageing Web Users]](/older-users/)
 :   Explains that designing products that are easier for older people to use is similar to designing for people with disabilities. Guidance on how to make your websites, web applications, and web tools work better for older users is covered in existing international accessibility standards from the W3C, including Web Content Accessibility Guidelines (WCAG).


### PR DESCRIPTION
From EOWG 6 January:
* [x] move the video icons from before to after (some done in [this PR](https://github.com/w3c/wai-fundamentals-overview/pull/85/files))
* [x] make clear what links to a video versus a page with links to videos (some done in [this PR](https://github.com/w3c/wai-fundamentals-overview/pull/85/files))
* [x] navigation "Accessibility: It's About People" -> "Accessibility is About People" [done](https://github.com/w3c/wai-website-data/commit/adf06a0344196c2ffff7fc0c3628cd6d37bc76ed)
* [x] unhide that in nav yml